### PR TITLE
git-flow CLI

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,13 +2,17 @@
   "name": "nodegit-flow",
   "version": "0.3.0",
   "description": "nodegit-flow contains gitflow methods that aren't include in the vanilla nodegit package",
-  "main": "build/src/index.js",
+  "main": "build/index.js",
   "scripts": {
-    "compile": "babel --sourceMaps --presets es2015 -d ./build/spec ./spec && babel --sourceMaps --presets es2015 -d ./build/src ./src",
+    "compile": "babel --presets es2015 --source-maps --debug 3050 ./spec --out-dir ./build/spec && babel --presets es2015 --source-maps --debug 3051 ./src --out-dir ./build",
+    "watch": "concurrently --raw \"babel --presets es2015 --source-maps --watch --debug 3050 ./spec --out-dir ./build/spec\" \"babel --presets es2015 --source-maps --watch --debug 3051 ./src --out-dir ./build\"",
     "eslint": "./node_modules/.bin/eslint src spec",
-    "prepublish": "babel --presets es2015 -d ./build/src ./src",
+    "prepublish": "babel --presets es2015 ./src --out-dir ./build",
     "debug-test": "npm run eslint && npm run compile && node-debug --debug-brk node_modules/.bin/jasmine-node build/spec/tests",
     "test": "npm run eslint && npm run compile && node_modules/.bin/jasmine-node build/spec/tests"
+  },
+  "bin": {
+    "git-flow": "./build/bin/git-flow.js"
   },
   "repository": {
     "type": "git",
@@ -31,7 +35,8 @@
   "homepage": "https://github.com/smith-kyle/nodegit-flow#readme",
   "devDependencies": {
     "babel-cli": "^6.3.15",
-    "babel-preset-es2015": "^6.3.13",
+    "babel-preset-es2015": "^6.18.0",
+    "concurrently": "^3.1.0",
     "eslint": "^1.9.0",
     "fs-extra": "^0.26.2",
     "jasmine-node": "mhevery/jasmine-node#Jasmine2.0",
@@ -39,5 +44,10 @@
   },
   "peerDependencies": {
     "nodegit": ">=0.13.0"
+  },
+  "dependencies": {
+    "bluebird": "^3.4.6",
+    "prompt": "^1.0.0",
+    "yargs": "^6.3.0"
   }
 }

--- a/src/bin/git-flow.js
+++ b/src/bin/git-flow.js
@@ -1,0 +1,148 @@
+#!/usr/bin/env node
+
+const promisify = require('../utils/Promisify');
+const yargs = require('yargs');
+const prompt = require('prompt');
+const promptGet = promisify(prompt.get);
+const Git = require('../');
+
+
+
+const openRepoPromise = Git.Repository.open('./');
+
+const getRepo = function() {
+  return openRepoPromise;
+};
+
+
+const flowVerbBuilder = function(type, yargs) {
+  yargs
+    .command('start <name>', 'Start', {}, (argv) => {
+      console.log('start', type, argv);
+      const { name } = argv;
+      return getRepo()
+        .then((repo) => {
+          if(type === 'feature') {
+            return Git.Flow.startFeature(repo, name);
+          }
+          else if(type === 'release') {
+            return Git.Flow.startRelease(repo, name);
+          }
+          else if(type === 'hotfix') {
+            return Git.Flow.startHotfix(repo, name);
+          }
+        })
+        .then((branch) => {
+          console.log('Branch created:', branch && branch.shorthand());
+        })
+        .catch((err) => {
+          console.log(`Error starting ${type}, ${name}`, err, err.stack);
+        });
+    })
+    .command('publish <name>', 'Start', {}, (argv) => {
+      console.log('publish', argv);
+      console.log('`publish` command is not supported yet');
+      /* * /
+      return getRepo()
+        .then((repo) => {
+          var config = repo.config();
+          var remoteOriginUrl = config.getString('remote.origin.url');
+
+          return Git.Remote.create(
+              repo,
+              'origin',
+              remoteOriginUrl
+            )
+            .then(function(remoteResult) {
+              remote = remoteResult;
+
+              // Create the push object for this remote
+              return remote.push(
+                // TODO: use proper ref
+                ["refs/heads/master:refs/heads/master"],
+                {
+                  callbacks: {
+                    credentials: function(url, userName) {
+                      return nodegit.Cred.sshKeyFromAgent(userName);
+                    }
+                  }
+                }
+              );
+            })
+        });
+        /* */
+    })
+    .command('finish <name>', 'Start', {}, (argv) => {
+      console.log('finish', argv);
+      const { name } = argv;
+      return getRepo()
+        .then((repo) => {
+          if(type === 'feature') {
+            return Git.Flow.finishFeature(repo, name);
+          }
+          else if(type === 'release') {
+            return Git.Flow.finishRelease(repo, name);
+          }
+          else if(type === 'hotfix') {
+            return Git.Flow.finishHotfix(repo, name);
+          }
+        })
+        .then(function(mergeCommit) {
+          console.log('asdf', arguments);
+          console.log('Branch finished:', mergeCommit && mergeCommit.id());
+        })
+        .catch((err) => {
+          console.log(`Error finishing ${type}, ${name}`, err, err.stack);
+        });
+    })
+    .command('pull <name>', 'Start', {}, (argv) => {
+      console.log('`pull` command is not supported yet');
+    })
+    .help('help')
+    .alias('help', 'h')
+    .argv;
+};
+
+
+const initHandler = function(argv) {
+  console.log('init', argv);
+
+  const defaultConfig = Git.Flow.getConfigDefault();
+  const promptSchema = Object.keys(defaultConfig).reduce((schema, propName) => {
+    schema.properties[propName] = {
+      default: defaultConfig[propName],
+      required: !!defaultConfig[propName]
+    };
+
+    return schema;
+  }, { properties: {} });
+
+  prompt.start();
+  return promptGet(promptSchema)
+    .catch((err) => {
+      console.log('Error prompting for response', err, err.stack);
+    })
+    .then((resultConfig) => {
+      return getRepo()
+        .then((repo) => {
+          return Git.Flow.init(repo, resultConfig);
+        })
+        .then(() => {
+          console.log('git-flow is now initialized.');
+        });
+    })
+    .catch((err) => {
+      console.log('Error initializing git-flow', err, err.stack);
+    });
+};
+
+
+
+yargs
+  .command('init', 'Initialize git-flow in repository', {}, initHandler)
+	.command('feature', 'Develop new features for upcoming releases', flowVerbBuilder.bind(null, 'feature'))
+	.command('release', 'Support preparation of a new production release', flowVerbBuilder.bind(null, 'release'))
+	.command('hotfix', 'Fix undesired state of a production release immediately ahead of a new production release', flowVerbBuilder.bind(null, 'hotfix'))
+  .help('help')
+  .alias('help', 'h')
+  .argv;

--- a/src/utils/FolderLoader.js
+++ b/src/utils/FolderLoader.js
@@ -10,7 +10,7 @@ function FolderLoader(absoluteFolder, onto, replace) {
     const fileStats = fs.lstatSync(path.join(absoluteFolder, file));
 
     // don't recurse down directories
-    if (file.indexOf('index.') && ~file.indexOf('.js') && !fileStats.isDirectory()) {
+    if (!(/index\.js$/).test(file) && (/.*?\.js$/).test(file) && !fileStats.isDirectory()) {
       onto[file.replace(replace, '')] = require('./' + relative + '/' + file);
     }
   });


### PR DESCRIPTION
Fixes https://github.com/smith-kyle/nodegit-flow/issues/9

git-flow CLI.

Still WIP but would love some discussion/suggestions on the direction this should go. If we want to suss this out through chat, I am [available on Gitter](https://gitter.im/MadLittleMods) but would be great to create a `nodegit-flow` specific room to keep the discussion out in the open. This could end up as a separate package if we don't want the CLI added here.

The reason for this over some of the other CLI options out there is so that there is an option on Windows that doesn't require cygwin. Plus JavaScript based :+1:

``` sh
git-flow init

git-flow feature start foo
git-flow feature finish foo

git-flow release start 0.1.0
git-flow release finish 0.1.0

git-flow hotfix start 0.1.1
git-flow hotfix finish 0.1.1
```

> ![](http://i.imgur.com/m0rywNX.png)
> 
> http://danielkummer.github.io/git-flow-cheatsheet/
## Todo
- [ ] Better logging
  - [ ] Should we use `console.log`?
- [ ] Figure out why `finish` `mergeCommit.id()` doesn't work as documented 😕 
- [ ] `publish`
- [ ] `push` (maybe)
