### PR TITLE
Fix branch deletion and add post checkout to start actions

### DIFF
--- a/src/Feature.js
+++ b/src/Feature.js
@@ -19,7 +19,7 @@ module.exports = (NodeGit, { constants, utils }, { Config }) => {
      */
     static startFeature(repo, featureName, options = {}) {
       const {
-        postCheckoutHook,
+        postCheckoutHook  = () => {},
         sha
       } = options;
 

--- a/src/Hotfix.js
+++ b/src/Hotfix.js
@@ -16,7 +16,10 @@ module.exports = (NodeGit, { constants, utils }, { Config }) => {
      * @param {Object}  options       Options for start hotfix
      * @return {Branch}   The nodegit branch for the hotfix
      */
-    static startHotfix(repo, hotfixVersion) {
+    static startHotfix(repo, hotfixVersion, options = {}) {
+      const {
+        postCheckoutHook
+      } = options;
       if (!repo) {
         return Promise.reject(new Error(constants.ErrorMessage.REPO_REQUIRED));
       }
@@ -44,7 +47,15 @@ module.exports = (NodeGit, { constants, utils }, { Config }) => {
         .then((localMasterCommit) => repo.createBranch(hotfixBranchName, localMasterCommit))
         .then((_hotfixBranch) => {
           hotfixBranch = _hotfixBranch;
-          return repo.checkoutBranch(hotfixBranch);
+          return repo.head()
+          .then((headRef) => {
+            return repo.checkoutBranch(hotfixBranch)
+            .then(() => repo.head())
+            .then(newHeadRef => postCheckoutHook(
+              headRef.target().toString(),
+              newHeadRef.target().toString()
+            ));
+          })
         })
         .then(() => hotfixBranch);
     }
@@ -150,7 +161,7 @@ module.exports = (NodeGit, { constants, utils }, { Config }) => {
             return Promise.resolve();
           }
 
-          return utils.Repo.safelyDeleteBranch(repo, hotfixBranchName, hotfixBranch, masterBranchName, postCheckoutHook);
+          return utils.Repo.safelyDeleteBranch(repo, hotfixBranchName, masterBranchName, postCheckoutHook);
         })
         .then(() => mergeCommit);
     }

--- a/src/Hotfix.js
+++ b/src/Hotfix.js
@@ -18,7 +18,7 @@ module.exports = (NodeGit, { constants, utils }, { Config }) => {
      */
     static startHotfix(repo, hotfixVersion, options = {}) {
       const {
-        postCheckoutHook
+        postCheckoutHook  = () => {}
       } = options;
       if (!repo) {
         return Promise.reject(new Error(constants.ErrorMessage.REPO_REQUIRED));

--- a/src/Release.js
+++ b/src/Release.js
@@ -17,7 +17,10 @@ module.exports = (NodeGit, { constants, utils }, { Config }) => {
      * @return {Branch}   The nodegit branch for the release
      */
     static startRelease(repo, releaseVersion, options = {}) {
-      const {sha} = options;
+      const {
+        postCheckoutHook,
+        sha
+      } = options;
 
       if (!repo) {
         return Promise.reject(new Error(constants.ErrorMessage.REPO_REQUIRED));
@@ -51,7 +54,15 @@ module.exports = (NodeGit, { constants, utils }, { Config }) => {
         .then((startingCommit) => repo.createBranch(releaseBranchName, startingCommit))
         .then((_releaseBranch) => {
           releaseBranch = _releaseBranch;
-          return repo.checkoutBranch(releaseBranch);
+          return repo.head()
+          .then((headRef) => {
+            return repo.checkoutBranch(releaseBranch)
+            .then(() => repo.head())
+            .then(newHeadRef => postCheckoutHook(
+              headRef.target().toString(),
+              newHeadRef.target().toString()
+            ));
+          })
         })
         .then(() => releaseBranch);
     }
@@ -156,7 +167,7 @@ module.exports = (NodeGit, { constants, utils }, { Config }) => {
             return Promise.resolve();
           }
 
-          return utils.Repo.safelyDeleteBranch(repo, releaseBranchName, releaseBranch, masterBranchName, postCheckoutHook);
+          return utils.Repo.safelyDeleteBranch(repo, releaseBranchName, masterBranchName, postCheckoutHook);
         })
         .then(() => mergeCommit);
     }

--- a/src/Release.js
+++ b/src/Release.js
@@ -18,7 +18,7 @@ module.exports = (NodeGit, { constants, utils }, { Config }) => {
      */
     static startRelease(repo, releaseVersion, options = {}) {
       const {
-        postCheckoutHook,
+        postCheckoutHook  = () => {},
         sha
       } = options;
 

--- a/src/utils/RepoUtils.js
+++ b/src/utils/RepoUtils.js
@@ -1,5 +1,5 @@
 module.exports = (NodeGit, MergeUtils) => ({
-  safelyDeleteBranch(repo, branchName, branchRef, branchNameToCheckoutIfUnsafe, postCheckoutHook = () => {}) {
+  safelyDeleteBranch(repo, branchName, branchNameToCheckoutIfUnsafe, postCheckoutHook = () => {}) {
     return repo.head()
       .then((headRef) => {
         if (branchName !== headRef.shorthand()) {
@@ -13,7 +13,7 @@ module.exports = (NodeGit, MergeUtils) => ({
             newHeadRef.target().toString()
           ));
       })
-      .then(() => branchRef.delete());
+      .then(() => NodeGit.Reference.remove(repo, `refs/heads/${branchName}`));
   },
 
   merge(toBranch, fromBranch, repo, processMergeMessageCallback = a => a, signingCallback) {


### PR DESCRIPTION
[Git hooks on Git Flow actions are behaving strangely](https://stagingapp.gitkraken.com/glo/view/card/8ce6b09b81c9469d8e18659b06eb261a)

This change will add `postCheckoutHook` handlers as an option to all `start` actions in `nodegit-flow`, and run the handler after `checkoutBranch` calls are made in those actions. It also fixes an issue in `RepoUtils.safelyDeleteBranch` where the `Reference.prototype.delete` would not work (error code -15) on outdated references after doing a rebase. Instead, `Reference.remove` is used with the full name of the branch. 