### PR TITLE
Update default master branch to 'main'

### DIFF
--- a/src/Config.js
+++ b/src/Config.js
@@ -34,7 +34,7 @@ module.exports = (NodeGit, { constants }) => {
     */
     static getConfigDefault() {
       return {
-        'gitflow.branch.master': 'master',
+        'gitflow.branch.master': 'main',
         'gitflow.branch.develop': 'develop',
 
         'gitflow.prefix.feature': 'feature/',


### PR DESCRIPTION
Git flow initialization fails if the master branch doesn't exist. An increasing majority of repos being git-flow-initialized from this point forward will have a `main` branch but no `master` branch, so changing the default will result in less manual configuration for users.

The [git flow project](https://github.com/nvie/gitflow) is essentially dead for 11 years, and its [most popular successor](https://github.com/petervanderdoes/gitflow-avh) also similarly dead. The most popular post-pandemic repo I could find is [here](https://github.com/CJ-Systems/gitflow-cjs). I bring these up to note that all three of them still have `gitflow.branch.master` as the config location, so while the actual name of the branch needs to be changed for practical reasons relating to a new `git` default, the _dotted path of the option_ probably shouldn't be changed (and might not even merit future-proofing), since it's specific only to git-flow and it's not obvious that the path will ever change if it hasn't happened already.

I plan to follow the existing history for this repo by updating the package.json in a push-to-master after this merges, and then publishing the package from there.